### PR TITLE
Bug fix

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -238,7 +238,7 @@ border-top-right-radius:5px;
   margin:4% auto;
 }
 .persona-comparison h3 {
-    margin-bottom:7%;
+    margin-bottom:4%;
     color:#C34500;
     z-index:999;
 }
@@ -269,14 +269,14 @@ border-top-right-radius:5px;
     transform: translateX(-50%);
     left:auto;
 
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     color: white;
-    /* white-space: nowrap; */
-    border-radius: 50%;
+    white-space: nowrap;
+    border-radius: 5px;
     background-color:#C34500;
-    padding:1.5% 1.5% 1% 1.5%;
-    width:30px;
-    height:30px;
+    padding:1% 1% 1% 1%;
+    width:auto;
+    height:auto;
     line-height:1; vertical-align:middle;
     text-align:center;
     box-shadow:2px 2px 3px  rgb(209, 208, 208);

--- a/frontend/src/contants.js
+++ b/frontend/src/contants.js
@@ -1,0 +1,11 @@
+export const SURVEY_MAX_AGREE_VALUE = 9;
+export const SURVEY_MIN_AGREE_VALUE = 1;
+
+// Define the pages and their corresponding keys for the Likert scales.
+export const SURVEY_PAGES = {
+  SelfEfficacy: ['sefHelpMenu', 'sefWatchedSomeone', 'sefNoOneHelped', 'sefSomeoneHelped', 'sefSomeoneShowedMe', 'sefUsedSimilar', 'sefNeverUsed', 'sefNoConfidence'], 
+  Motivation: ['mSuiteApps', 'mSuiteLookGood', 'mSuiteTester'], 
+  LearningStyle:  ['lsLesserKnownFeatures', 'lsLookAhead', 'lsUpdateSettings'], 
+  InformationProcessingStyle: ['ipsGatherInfo', 'ipsResearch', 'ipsUnderstandDirection'], 
+  AttitudeTowardsRisk: ['atrAvoidAdvancedSections', 'atrAvoidDanger', 'atrUseUnproven'] 
+};

--- a/frontend/src/modules/quizzes/SurveySummary.jsx
+++ b/frontend/src/modules/quizzes/SurveySummary.jsx
@@ -67,7 +67,7 @@ const pageTotals = Object.entries(pages).reduce((totals, [page, keys]) => {
   // Calculate total for the current page, applying reversal where necessary
   const total = keys.reduce((sum, key) => {
     let value = surveyData[key] || 0; // Default to 0 if no value found
-    if (questionsToReverse.includes(key)) {
+    if (questionsToReverse.includes(key) && value) {
       value = getReversedValue(value); // Reverse the value if it's in the reversal list
     }
     return sum + value;

--- a/frontend/src/modules/quizzes/SurveySummary.jsx
+++ b/frontend/src/modules/quizzes/SurveySummary.jsx
@@ -8,6 +8,7 @@ import  personas  from '../data/personasObject';
 
 import { Link } from 'react-router-dom';
 import { useNavigation } from '../utils/NavigationContext';
+import { SURVEY_PAGES, SURVEY_MAX_AGREE_VALUE, SURVEY_MIN_AGREE_VALUE } from '../../contants';
 
 // List of question names where reversal should happen
 const questionsToReverse = [
@@ -48,53 +49,108 @@ function SurveySummary() {
   const abiImage = abiPersona?.portrait;
   const patImage = patPersona?.portrait;
 
-  // Define the pages and their corresponding keys for the Likert scales.
-  const pages = {
-      SelfEfficacy: ['sefHelpMenu', 'sefWatchedSomeone', 'sefNoOneHelped', 'sefSomeoneHelped', 'sefSomeoneShowedMe', 'sefUsedSimilar', 'sefNeverUsed', 'sefNoConfidence'], 
-      Motivation: ['mSuiteApps', 'mSuiteLookGood', 'mSuiteTester'], 
-      LearningStyle:  ['lsLesserKnownFeatures', 'lsLookAhead', 'lsUpdateSettings'], 
-      InformationProcessingStyle: ['ipsGatherInfo', 'ipsResearch', 'ipsUnderstandDirection'], 
-      AttitudeTowardsRisk: ['atrAvoidAdvancedSections', 'atrAvoidDanger', 'atrUseUnproven'] 
-    };
+  // Converts page score to a number between 0 and 1, inclusive
+  const normalizedPageScore = (score, page) => {
+    const maxTimPageScore = numPageResponses[page]*SURVEY_MAX_AGREE_VALUE;
+    const minTimPageScore = numPageResponses[page]*SURVEY_MIN_AGREE_VALUE;
+    const denominator = maxTimPageScore - minTimPageScore;
+    const numerator = score - minTimPageScore;
+    return numerator / denominator;
+  };
 
-// Adjust totals by applying the reversal logic
-const pageTotals = Object.entries(pages).reduce((totals, [page, keys]) => {
-  if (!page || !keys) {
-    console.error("Invalid page or keys:", { page, keys });
-    return totals;
-  }
-
-  // Calculate total for the current page, applying reversal where necessary
-  const total = keys.reduce((sum, key) => {
-    let value = surveyData[key] || 0; // Default to 0 if no value found
-    if (questionsToReverse.includes(key) && value) {
-      value = getReversedValue(value); // Reverse the value if it's in the reversal list
+  // Number of survey responses for each page
+  const numPageResponses = Object.entries(SURVEY_PAGES).reduce((responseTotals, [page, keys]) => {
+    if (!page || !keys) {
+      console.error("Invalid page or keys:", { page, keys });
+      return responseTotals;
     }
-    return sum + value;
-  }, 0);
 
-  console.log(`Total for ${page}:`, total);  // Logging page and total
+    const total = keys.reduce((sum, key) => {
+      let value = surveyData[key] ? 1 : 0;
+      return sum + value;
+    }, 0);
 
-  totals[page] = total;
-  return totals;
-}, {});
+    console.log(`Total number of responses for ${page}:`, total);  // Number of survey responses for the page
+
+    responseTotals[page] = total;
+    return responseTotals;
+  }, {});
+
+  // Adjust totals by applying the reversal logic
+  const pageTotals = Object.entries(SURVEY_PAGES).reduce((totals, [page, keys]) => {
+    if (!page || !keys) {
+      console.error("Invalid page or keys:", { page, keys });
+      return totals;
+    }
+
+    // Calculate total for the current page, applying reversal where necessary
+    const total = keys.reduce((sum, key) => {
+      let value = surveyData[key] || 0; // Default to 0 if no value found
+      if (questionsToReverse.includes(key) && value) {
+        value = getReversedValue(value); // Reverse the value if it's in the reversal list
+      }
+      return sum + value;
+    }, 0);
+
+    console.log(`Total for ${page}:`, total);  // Logging page and total
+
+    totals[page] = total;
+    return totals;
+  }, {});
 
 
-    // Calculate the grand total
-    const grandTotal = Object.values(pageTotals).reduce((sum, total) => sum + total, 0);
+  // Calculate the grand total
+  const grandTotal = Object.values(pageTotals).reduce((sum, total) => sum + total, 0);
 
+  // Calculates how Abi-like and Tim-like the respondant is for current facet
+  // Expects a score between 0 and 1, inclusive
+  const abiTimPercents = (score) => {
+    const timProportion = score;
+    const abiProportion = 1 - timProportion;
+    const timPercent = (timProportion * 100).toFixed(0);
+    const abiPercent = (abiProportion * 100).toFixed(0);
+    return {
+      abiPercent: `${abiPercent}%`,
+      timPercent: `${timPercent}%`
+    };
+  };
 
-    useEffect(() => {
-      markSummaryAsVisited();
-    }, [markSummaryAsVisited]);
+  const abiPercent = (score) => { return abiTimPercents(score).abiPercent; };
+  const timPercent = (score) => { return abiTimPercents(score).timPercent; };
+
+  // Calculate how Tim-like the respondant is, across all facets for which they provided answers
+  const averageTimScore = () => {
+    const { sum, count } = Object.entries(pageTotals).reduce((acc, [key, value]) => {  
+
+        const score = normalizedPageScore(value, key);
+        
+        // Check if score is a valid number
+        if (typeof score === 'number' && !isNaN(score)) {
+            acc.sum += score; // Add score to sum
+            acc.count++;      // Increment count of valid scores
+        }
+        
+        return acc; // Return the accumulator
+    }, { sum: 0, count: 0 }); // Initial accumulator with sum and count
+
+    const averageScore = count > 0 ? sum / count : 0; // Avoid division by zero
+    console.log('Total Sum:', sum); // Debugging
+    console.log('Count of Pages with Valid Scores:', count); // Debugging
+    console.log('Average Score:', averageScore); // Debugging
+    return count > 0 ? averageScore: NaN;
+  };
+
+  useEffect(() => {
+    markSummaryAsVisited();
+  }, [markSummaryAsVisited]);
 
   return (
     <>
       <h2>Survey Summary</h2>
       <article>
       <p>Based on your selections on each of the survey pages, 
-        your <strong>total score is: {grandTotal}</strong>. 
-        Here is how your scores compare to the personas:</p>
+        your <strong>overall, you are {abiPercent(averageTimScore())} like Abi and {timPercent(averageTimScore())} like Tim</strong>. 
+        Here is how you compare to the personas for each facet:</p>
 
         <div className="survey-summary">
         {Object.entries(pageTotals).map(([page, total]) => {
@@ -104,11 +160,16 @@ const pageTotals = Object.entries(pages).reduce((totals, [page, keys]) => {
               return null; // Skip rendering if persona, page, or total is missing
             }
 
+            const pageScore = normalizedPageScore(total, page);
+
             return (
               <PersonaComparison
               key={page}
+              page={page}
               facet={toTitleCase(page)}
-              score={total}  // Use the reversed or normal total
+              score={pageScore} // Value between 0 and 1, inclusive
+              abiPercent={abiPercent(pageScore)}
+              timPercent={timPercent(pageScore)}
               timImage={timImage}
               abiImage={abiImage}
               patImage={patImage}

--- a/frontend/src/modules/utils/ButtonGroup.jsx
+++ b/frontend/src/modules/utils/ButtonGroup.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { SurveyContext } from './SurveyContext';
+import { SURVEY_MAX_AGREE_VALUE, SURVEY_MIN_AGREE_VALUE } from '../../contants';
 
 // This component will generate the Likert buttons (9)
 const ButtonGroup = ({ name }) => {
@@ -15,8 +16,8 @@ const ButtonGroup = ({ name }) => {
   return (
     <div className="buttonGroup">
       <p className="scale">
-        {[...Array(9)].map((_, index) => {
-          const value = index + 1;
+        {[...Array(SURVEY_MAX_AGREE_VALUE)].map((_, index) => {
+          const value = index + SURVEY_MIN_AGREE_VALUE;
           return (
             <button
               key={value}

--- a/frontend/src/modules/utils/PersonaComparison.jsx
+++ b/frontend/src/modules/utils/PersonaComparison.jsx
@@ -8,33 +8,25 @@ Attitude Risk: Tim-pic —————————— — O - Abi-pic
 
 */
 
-const PersonaComparison = ({ facet, score, timImage, abiImage, patImage }) => {
+const PersonaComparison = ({ page, facet, score, abiPercent, timPercent, timImage, abiImage, patImage }) => {
   console.log(`Facet: ${facet}, Score: ${score}`); // Debugging
 
-  const scorePosition = (score) => {
-    console.log(`Score: ${score}`); // Debugging
-    const clampedScore = Math.max(1, Math.min(score, 9)); // Ensure score is within 1-9
-    const position = ((clampedScore - 1) / 8) * 80; // Scale to width used in the stylesheet. 
-    console.log(`Position: ${position}%`);
-    return `${position}%`;
-  };
+  // const testScore = 5; // Try a known score value
+  // console.log(scorePosition(testScore)); // Check the output
 
-    // const testScore = 5; // Try a known score value
-    // console.log(scorePosition(testScore)); // Check the output
+  return (
+    <div className="persona-comparison">
+      <h3>{facet}</h3>
+      <p className="comparison-bar" >
+        <img src={abiImage} alt="Abi, Abigail, Abishek"  title="Abi, Abigail, Abishek"  className="persona-image abi" />
+        <span className="score-marker" style={{ left: timPercent }}>{abiPercent} Abi, {timPercent} Tim</span>
+          {/* <img  src={patImage} alt="Pat, Patricia, Patrick" title="Pat, Patricia, Patrick" className="persona-image pat grayed" /> */}
+          <img src={timImage} alt="Tim, Timara, Timothy"  title="Tim, Timara, Timothy" className="persona-image tim" />
 
-    return (
-      <div className="persona-comparison">
-        <h3>{facet}</h3>
-        <p className="comparison-bar" >
-          <img src={abiImage} alt="Abi, Abigail, Abishek"  title="Abi, Abigail, Abishek"  className="persona-image abi" />
-          <span className="score-marker" style={{ left: scorePosition(score) }}>{score}</span>
-            {/* <img  src={patImage} alt="Pat, Patricia, Patrick" title="Pat, Patricia, Patrick" className="persona-image pat grayed" /> */}
-            <img src={timImage} alt="Tim, Timara, Timothy"  title="Tim, Timara, Timothy" className="persona-image tim" />
+      </p>
 
-        </p>
+    </div>
+  );
+};
 
-      </div>
-    );
-  };
-  
-  export default PersonaComparison;
+export default PersonaComparison;


### PR DESCRIPTION
If there are no survey responses, now no spectra will appear on the summary. Previously, three spectra would show when there were no survey responses. This is because the questions that needed to be reversed were getting reversed from zeros to 10s